### PR TITLE
Set filePath for relative mj-include to work.

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function(content) {
 
   let result = {};
   try {
-    result = mjml2html(content, { level: 'soft' });
+    result = mjml2html(content, { level: 'soft', filePath: this.resourcePath });
   } catch (e) {
     result.html = displayErrors.bind(this)(e);
   }
@@ -93,7 +93,7 @@ function trackMjIncludeChanges(html) {
   const re = /(mj-include path="((?:\.|\.\.)\/.*?)")/gi;
   let match;
   while ((match = re.exec(html))) {
-    const imgPath = path.resolve(match[2]);
+    const imgPath = path.normalize(`${this.context}/${match[2]}`);
     this.addDependency(imgPath);
   }
 }


### PR DESCRIPTION
Hey @nodkz,

I was getting issues with my mj-includes inside my mjml because they're relative to the mjml file itself.
The mjml library has a fix for this by settiing filePath in the mjml2html options.

I also used the path.normalize code you used for images to fix the tracking of mj-include dependencies